### PR TITLE
fix: 1. 显示设置元素的 left、top 为 0；2. 全局样式会影响 img.width 不能获取源尺寸大小

### DIFF
--- a/src/preloader.js
+++ b/src/preloader.js
@@ -58,6 +58,7 @@
         var style = this.div.style
         style.visibility = 'hidden'
         style.position = 'absolute'
+        style.top = style.left = '0'
         style.width = style.height = '10px'
         style.overflow = 'hidden'
         style.transform = style.msTransform = style.webkitTransform = style.oTransform = 'translate(-10px, -10px)'
@@ -104,6 +105,10 @@
                 }, diff) : self.done(resource, image)
             }
             image.src = resource
+            image.style.width = 'auto'
+            image.style.height = 'auto'
+            image.style.maxWidth = 'none'
+            image.style.maxHeight = 'none'
         }
         this.audioLoader = function (resource) {
             var self = this


### PR DESCRIPTION
对应标题：
1. 不显示设置 left、top，则绝对定位的元素位置依然会处于原位置（此时未必刚好处于页面 (0,0) 位置 ）。
2. 全局样式 img { max-width: 100% } 会影响 img.width 获取图片源大小。因为其父元素的大小为 10px。尽管可以通过 img. naturalWidth 获取。